### PR TITLE
Fix certificate renewal: do not assume a saved ACME account has a contact field

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ See [AMCS.js](https://www.npmjs.com/package/acme) for more details.
 -->
 
 ## Changelog
+### **WORK IN PROGRESS**
+- (chris299) Fixed certificate renewal failing with "Cannot read properties of undefined (reading '0')"
+
 ### 4.0.3 (2026-08-03)
 - (@GermanBluefox) Migrated to admin 8
 - (@GermanBluefox) Adapter requires admin >= 8.0.0 now

--- a/build/main.js
+++ b/build/main.js
@@ -295,7 +295,15 @@ class AcmeAdapter extends utils.Adapter {
             const accountObject = await this.getObjectAsync(accountObjectId);
             if (accountObject) {
                 this.log.debug(`Loaded existing ACME account: ${JSON.stringify(accountObject)}`);
-                if (accountObject.native?.full?.contact[0] !== `mailto:${this.config.maintainerEmail}`) {
+                // Let's Encrypt stopped storing contact information in January
+                // 2025, and its newAccount response no longer carries a
+                // `contact` field, so a saved account may legitimately have
+                // none. Two things follow: the index must be guarded, and a
+                // missing contact has to mean "cannot verify" rather than
+                // "does not match" -- otherwise a new account is registered on
+                // every single run.
+                const savedContact = accountObject.native?.full?.contact?.[0];
+                if (savedContact && savedContact !== `mailto:${this.config.maintainerEmail}`) {
                     this.log.warn('Saved account does not match maintainer email, will recreate.');
                 }
                 else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -318,7 +318,15 @@ class AcmeAdapter extends utils.Adapter {
             if (accountObject) {
                 this.log.debug(`Loaded existing ACME account: ${JSON.stringify(accountObject)}`);
 
-                if (accountObject.native?.full?.contact[0] !== `mailto:${this.config.maintainerEmail}`) {
+                // Let's Encrypt stopped storing contact information in January
+                // 2025, and its newAccount response no longer carries a
+                // `contact` field, so a saved account may legitimately have
+                // none. Two things follow: the index must be guarded, and a
+                // missing contact has to mean "cannot verify" rather than
+                // "does not match" -- otherwise a new account is registered on
+                // every single run.
+                const savedContact = accountObject.native?.full?.contact?.[0];
+                if (savedContact && savedContact !== `mailto:${this.config.maintainerEmail}`) {
                     this.log.warn('Saved account does not match maintainer email, will recreate.');
                 } else {
                     this.account = accountObject.native as AcmeAccount;


### PR DESCRIPTION
Every run after the first fails with

```
Failed in ACME init/generation: Cannot read properties of undefined (reading '0')
```

which means **certificate renewal never happens**: the first run registers an account, and every later one dies before it looks at a single collection. Closes #191.

There are two separate problems in that one line.

**The crash.** `accountObject.native?.full?.contact[0]` guards `full` but not `contact`. Optional chaining short-circuits the whole chain only when the operand of `?.` is nullish — so on the very first run, with no saved account and therefore no `full`, the `[0]` is never evaluated and nothing goes wrong. Once an account has been saved, `full` exists, evaluation continues to `.contact`, and then to `[0]` on `undefined`. That is exactly why this reproduces on the *second* run and not the first.

**Why `contact` is missing at all.** Let's Encrypt [announced in January 2025](https://letsencrypt.org/docs/expiration-emails/) that it would stop sending expiration notifications, and it no longer stores contact information; its `newAccount` response no longer carries a `contact` field. It broke [other ACME clients](https://community.letsencrypt.org/t/did-you-change-the-response-of-new-account/238188) the same way. A saved account created since then legitimately has none — which is also why this hits new installations rather than long-standing ones, and why the issue has stayed quiet for so long.

So guarding the index is not sufficient. Comparing an absent contact against `mailto:...` is always unequal, and the adapter would then warn *"Saved account does not match maintainer email, will recreate"* and register a fresh account on **every** run, eventually hitting the registration rate limit. A missing contact therefore now means "cannot verify" and the saved account is kept.

**Verification.** In an ioBroker dev environment (js-controller 7.2.2, admin 8.0.5) against Let's Encrypt staging, on one and the same saved account:

```
before   Loaded existing ACME account … (no contact field)
         Failed in ACME init/generation: Cannot read properties of undefined (reading '0')

after    Loaded existing ACME account … (same account, still no contact)
         Collection winkler expiring soon - will renew
         Collection winkler order success
```

The renewal itself was triggered by placing a certificate expiring in three days into the collection, so the `expiring soon` branch ran for real rather than being reasoned about. The reissued certificate came back from the staging CA with 90 days of validity and a new serial.

One caveat on that verification, since it is worth stating: the renewal completed in 62 s because Let's Encrypt reused the existing authorizations, which are valid for 30 days and the previous issuance was 27 minutes old. A production renewal happens roughly 83 days after issuance, outside that window, and will run the full challenge cycle. That cycle was verified separately in the same environment.
