### PR TITLE
Restore POST-as-GET polling in ACME.js so orders can complete (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ See [AMCS.js](https://www.npmjs.com/package/acme) for more details.
 -->
 
 ## Changelog
+### **WORK IN PROGRESS**
+- (chris299) Fixed certificate issuance failing against current Let's Encrypt with 409 / "Unhandled status '403'"
+
 ### 4.0.3 (2026-08-03)
 - (@GermanBluefox) Migrated to admin 8
 - (@GermanBluefox) Adapter requires admin >= 8.0.0 now

--- a/build/lib/root-acme-post-as-get.js
+++ b/build/lib/root-acme-post-as-get.js
@@ -1,0 +1,260 @@
+"use strict";
+/* eslint-disable */
+/*
+ * Restores POST-as-GET polling in ACME.js.
+ *
+ * The two functions below are copied verbatim from @root/acme v3.1.1 -- git tag
+ * v3.1.1, commit 45fd6962f259c6399de05589848d68be42894316, upstream commit
+ * 0aa939a2 "Bug fix: Polling status using POST-as-GET wherever possible" -- a
+ * release that was tagged in May 2021 and never published to npm. npm serves
+ * 3.1.0, whose versions of these two functions re-send requests that today's
+ * Let's Encrypt rejects:
+ *
+ *   _postChallenge     a challenge that comes back "pending" from the trigger
+ *                      POST is triggered a second time; Boulder answers the
+ *                      repeat with 409, which ACME.js then misreads as a
+ *                      challenge status. -> (E_STATE_UKN) challenge state '409'
+ *
+ *   _pollOrderStatus   on "processing" the CSR is POSTed to the finalize URL
+ *                      again instead of polling the order URL as RFC 8555 §7.4
+ *                      asks; Boulder answers orderNotReady, 403.
+ *                      -> Didn't finalize order: Unhandled status '403'  (#49)
+ *
+ * Both are races, which is why the same adapter version issues certificates for
+ * some users and not others.
+ *
+ * Do not reformat or "improve" this file. Its only virtue is being diffable
+ * against upstream. It should be deleted the moment @root/acme ships a version
+ * that contains the fix, or the library is replaced.
+ */
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.applyPostAsGetPolling = applyPostAsGetPolling;
+const acme_1 = __importDefault(require("acme"));
+const utils_js_1 = __importDefault(require("@root/acme/utils.js"));
+const errors_js_1 = __importDefault(require("@root/acme/errors.js"));
+const bytes_js_1 = __importDefault(require("@root/encoding/bytes.js"));
+/** Overwrites the two functions on the shared ACME object. Idempotent. */
+function applyPostAsGetPolling() {
+    acme_1.default._postChallenge = function (me, options, kid, auth) {
+        var RETRY_INTERVAL = me.retryInterval || 1000;
+        var DEAUTH_INTERVAL = me.deauthWait || 10 * 1000;
+        var MAX_POLL = me.retryPoll || 8;
+        var MAX_PEND = me.retryPending || 4;
+        var count = 0;
+        var altname = acme_1.default._untame(auth.identifier.value, auth.wildcard);
+        /*
+       POST /acme/authz/1234 HTTP/1.1
+       Host: example.com
+       Content-Type: application/jose+json
+    
+       {
+         "protected": base64url({
+           "alg": "ES256",
+           "kid": "https://example.com/acme/acct/1",
+           "nonce": "xWCM9lGbIyCgue8di6ueWQ",
+           "url": "https://example.com/acme/authz/1234"
+         }),
+         "payload": base64url({
+           "status": "deactivated"
+         }),
+         "signature": "srX9Ji7Le9bjszhu...WTFdtujObzMtZcx4"
+       }
+       */
+        function deactivate() {
+            //#console.debug('[ACME.js] deactivate:');
+            return utils_js_1.default._jwsRequest(me, {
+                accountKey: options.accountKey,
+                url: auth.url,
+                protected: { kid: kid },
+                payload: bytes_js_1.default.strToBuf(JSON.stringify({ status: 'deactivated' }))
+            }).then(function ( /*#resp*/) {
+                //#console.debug('deactivate challenge: resp.body:');
+                //#console.debug(resp.body);
+                return acme_1.default._wait(DEAUTH_INTERVAL);
+            });
+        }
+        function pollStatus() {
+            if (count >= MAX_POLL) {
+                var err = new Error("[ACME.js] stuck in bad pending/processing state for '" +
+                    altname +
+                    "'");
+                // Only deviation from upstream: TypeScript will not let an ad-hoc
+                // property be set on Error.
+                err.context = 'present_challenge';
+                return Promise.reject(err);
+            }
+            count += 1;
+            //#console.debug('\n[DEBUG] statusChallenge\n');
+            // POST-as-GET
+            return utils_js_1.default._jwsRequest(me, {
+                accountKey: options.accountKey,
+                url: auth.url,
+                protected: { kid: kid },
+                payload: bytes_js_1.default.binToBuf('')
+            })
+                .then(checkResult)
+                .catch(transformError);
+        }
+        function checkResult(resp) {
+            acme_1.default._notify(me, options, 'challenge_status', {
+                // API-locked
+                status: resp.body.status,
+                type: auth.type,
+                altname: altname
+            });
+            // State can be pending while waiting ACME server to transition to
+            // processing
+            if ('pending' === resp.body.status) {
+                if (count >= MAX_PEND) {
+                    return acme_1.default._wait(RETRY_INTERVAL)
+                        .then(deactivate)
+                        .then(respondToChallenge);
+                }
+                //#console.debug('poll: again', auth.url);
+                return acme_1.default._wait(RETRY_INTERVAL).then(pollStatus);
+            }
+            if ('processing' === resp.body.status) {
+                //#console.debug('poll: again', auth.url);
+                return acme_1.default._wait(RETRY_INTERVAL).then(pollStatus);
+            }
+            // REMOVE DNS records as soon as the state is non-processing
+            // (valid or invalid or other)
+            try {
+                options.challenges[auth.type]
+                    .remove({ challenge: auth })
+                    .catch(function (err) {
+                    err.action = 'challenge_remove';
+                    err.altname = auth.altname;
+                    err.type = auth.type;
+                    acme_1.default._notify(me, options, 'error', err);
+                });
+            }
+            catch (e) { }
+            if ('valid' === resp.body.status) {
+                if (me.debug) {
+                    console.debug('poll: valid');
+                }
+                return resp.body;
+            }
+            var errmsg;
+            if (!resp.body.status) {
+                errmsg =
+                    "[ACME.js] (E_STATE_EMPTY) empty challenge state for '" +
+                        altname +
+                        "':" +
+                        JSON.stringify(resp.body);
+            }
+            else if ('invalid' === resp.body.status) {
+                errmsg =
+                    "[ACME.js] (E_STATE_INVALID) challenge state for '" +
+                        altname +
+                        "': '" +
+                        //resp.body.status +
+                        JSON.stringify(resp.body) +
+                        "'";
+            }
+            else {
+                errmsg =
+                    "[ACME.js] (E_STATE_UKN) challenge state for '" +
+                        altname +
+                        "': '" +
+                        resp.body.status +
+                        "'";
+            }
+            return Promise.reject(new Error(errmsg));
+        }
+        function transformError(e) {
+            var err = e;
+            if (err.urn) {
+                err = new Error('[acme-v2] ' +
+                    auth.altname +
+                    ' status:' +
+                    e.status +
+                    ' ' +
+                    e.detail);
+                err.auth = auth;
+                err.altname = auth.altname;
+                err.type = auth.type;
+                err.code =
+                    'invalid' === e.status ? 'E_ACME_CHALLENGE' : 'E_ACME_UNKNOWN';
+            }
+            throw err;
+        }
+        function respondToChallenge() {
+            //#console.debug('[ACME.js] responding to accept challenge:');
+            // POST-as-POST (empty JSON object)
+            return utils_js_1.default._jwsRequest(me, {
+                accountKey: options.accountKey,
+                url: auth.url,
+                protected: { kid: kid },
+                payload: bytes_js_1.default.strToBuf(JSON.stringify({}))
+            })
+                .then(checkResult)
+                .catch(transformError);
+        }
+        return respondToChallenge();
+    };
+    acme_1.default._pollOrderStatus = function (me, options, kid, order, verifieds) {
+        var csr64 = acme_1.default._csrToUrlBase64(options.csr);
+        var body = { csr: csr64 };
+        var payload = JSON.stringify(body);
+        function processResponse(resp) {
+            acme_1.default._notify(me, options, 'certificate_status', {
+                subject: options.domains[0],
+                status: resp.body.status
+            });
+            // https://tools.ietf.org/html/draft-ietf-acme-acme-12#section-7.1.3
+            // Possible values are: "pending" => ("invalid" || "ready") => "processing" => "valid"
+            if ('valid' === resp.body.status) {
+                var voucher = resp.body;
+                voucher._certificateUrl = resp.body.certificate;
+                return voucher;
+            }
+            if ('processing' === resp.body.status) {
+                return acme_1.default._wait().then(pollStatus);
+            }
+            if (me.debug) {
+                console.debug('Error: bad status:\n' + JSON.stringify(resp.body, null, 2));
+            }
+            if ('pending' === resp.body.status) {
+                return Promise.reject(new Error("Did not finalize order: status 'pending'." +
+                    ' Best guess: You have not accepted at least one challenge for each domain:\n' +
+                    "Requested: '" +
+                    options.domains.join(', ') +
+                    "'\n" +
+                    "Validated: '" +
+                    verifieds.join(', ') +
+                    "'\n" +
+                    JSON.stringify(resp.body, null, 2)));
+            }
+            if ('invalid' === resp.body.status) {
+                return Promise.reject(errors_js_1.default.ORDER_INVALID(options, verifieds, resp));
+            }
+            if ('ready' === resp.body.status) {
+                return Promise.reject(errors_js_1.default.DOUBLE_READY_ORDER(options, verifieds, resp));
+            }
+            return Promise.reject(errors_js_1.default.UNHANDLED_ORDER_STATUS(options, verifieds, resp));
+        }
+        function pollStatus() {
+            return utils_js_1.default._jwsRequest(me, {
+                accountKey: options.accountKey,
+                url: order._orderUrl,
+                protected: { kid: kid },
+                payload: bytes_js_1.default.binToBuf('')
+            }).then(processResponse);
+        }
+        function finalizeOrder() {
+            //#console.debug('[ACME.js] pollCert:', order._finalizeUrl);
+            return utils_js_1.default._jwsRequest(me, {
+                accountKey: options.accountKey,
+                url: order._finalizeUrl,
+                protected: { kid: kid },
+                payload: bytes_js_1.default.strToBuf(payload)
+            }).then(processResponse);
+        }
+        return finalizeOrder();
+    };
+}

--- a/build/main.js
+++ b/build/main.js
@@ -50,6 +50,7 @@ const pem_1 = __importDefault(require("@root/pem"));
 const x509_js_1 = __importDefault(require("x509.js"));
 const package_json_1 = __importDefault(require("../package.json"));
 const http_01_challenge_server_1 = require("./lib/http-01-challenge-server");
+const root_acme_post_as_get_1 = require("./lib/root-acme-post-as-get");
 const accountObjectId = 'account';
 // Renew 7 days before expiry
 const renewWindow = 60 * 60 * 24 * 7 * 1000;
@@ -270,6 +271,11 @@ class AcmeAdapter extends utils.Adapter {
                 ? 'https://acme-staging-v02.api.letsencrypt.org/directory'
                 : 'https://acme-v02.api.letsencrypt.org/directory';
             this.log.debug(`Using URL: ${directoryUrl}`);
+            // ACME.js as published on npm re-sends the challenge trigger and
+            // the order finalization, and today's Let's Encrypt rejects the
+            // repeats with 409 and 403 (#49). Restore the polling behaviour of
+            // the unpublished upstream 3.1.1 before anything uses the client.
+            (0, root_acme_post_as_get_1.applyPostAsGetPolling)();
             this.acme = acme_1.default.create({
                 maintainerEmail: this.config.maintainerEmail,
                 packageAgent: `${package_json_1.default.name}/${package_json_1.default.version}`,

--- a/src/lib/root-acme-post-as-get.ts
+++ b/src/lib/root-acme-post-as-get.ts
@@ -1,0 +1,300 @@
+/* eslint-disable */
+/*
+ * Restores POST-as-GET polling in ACME.js.
+ *
+ * The two functions below are copied verbatim from @root/acme v3.1.1 -- git tag
+ * v3.1.1, commit 45fd6962f259c6399de05589848d68be42894316, upstream commit
+ * 0aa939a2 "Bug fix: Polling status using POST-as-GET wherever possible" -- a
+ * release that was tagged in May 2021 and never published to npm. npm serves
+ * 3.1.0, whose versions of these two functions re-send requests that today's
+ * Let's Encrypt rejects:
+ *
+ *   _postChallenge     a challenge that comes back "pending" from the trigger
+ *                      POST is triggered a second time; Boulder answers the
+ *                      repeat with 409, which ACME.js then misreads as a
+ *                      challenge status. -> (E_STATE_UKN) challenge state '409'
+ *
+ *   _pollOrderStatus   on "processing" the CSR is POSTed to the finalize URL
+ *                      again instead of polling the order URL as RFC 8555 §7.4
+ *                      asks; Boulder answers orderNotReady, 403.
+ *                      -> Didn't finalize order: Unhandled status '403'  (#49)
+ *
+ * Both are races, which is why the same adapter version issues certificates for
+ * some users and not others.
+ *
+ * Do not reformat or "improve" this file. Its only virtue is being diffable
+ * against upstream. It should be deleted the moment @root/acme ships a version
+ * that contains the fix, or the library is replaced.
+ */
+
+import ACME from 'acme';
+import U from '@root/acme/utils.js';
+import E from '@root/acme/errors.js';
+import Enc from '@root/encoding/bytes.js';
+
+/** Overwrites the two functions on the shared ACME object. Idempotent. */
+export function applyPostAsGetPolling(): void {
+	ACME._postChallenge = function (me, options, kid, auth) {
+		var RETRY_INTERVAL = me.retryInterval || 1000;
+		var DEAUTH_INTERVAL = me.deauthWait || 10 * 1000;
+		var MAX_POLL = me.retryPoll || 8;
+		var MAX_PEND = me.retryPending || 4;
+		var count = 0;
+	
+		var altname = ACME._untame(auth.identifier.value, auth.wildcard);
+	
+		/*
+	   POST /acme/authz/1234 HTTP/1.1
+	   Host: example.com
+	   Content-Type: application/jose+json
+	
+	   {
+	     "protected": base64url({
+	       "alg": "ES256",
+	       "kid": "https://example.com/acme/acct/1",
+	       "nonce": "xWCM9lGbIyCgue8di6ueWQ",
+	       "url": "https://example.com/acme/authz/1234"
+	     }),
+	     "payload": base64url({
+	       "status": "deactivated"
+	     }),
+	     "signature": "srX9Ji7Le9bjszhu...WTFdtujObzMtZcx4"
+	   }
+	   */
+		function deactivate() {
+			//#console.debug('[ACME.js] deactivate:');
+			return U._jwsRequest(me, {
+				accountKey: options.accountKey,
+				url: auth.url,
+				protected: { kid: kid },
+				payload: Enc.strToBuf(JSON.stringify({ status: 'deactivated' }))
+			}).then(function (/*#resp*/) {
+				//#console.debug('deactivate challenge: resp.body:');
+				//#console.debug(resp.body);
+				return ACME._wait(DEAUTH_INTERVAL);
+			});
+		}
+	
+		function pollStatus() {
+			if (count >= MAX_POLL) {
+				var err = new Error(
+					"[ACME.js] stuck in bad pending/processing state for '" +
+						altname +
+						"'"
+				);
+				// Only deviation from upstream: TypeScript will not let an ad-hoc
+				// property be set on Error.
+				(err as any).context = 'present_challenge';
+				return Promise.reject(err);
+			}
+	
+			count += 1;
+	
+			//#console.debug('\n[DEBUG] statusChallenge\n');
+			// POST-as-GET
+			return U._jwsRequest(me, {
+				accountKey: options.accountKey,
+				url: auth.url,
+				protected: { kid: kid },
+				payload: Enc.binToBuf('')
+			})
+				.then(checkResult)
+				.catch(transformError);
+		}
+	
+		function checkResult(resp) {
+			ACME._notify(me, options, 'challenge_status', {
+				// API-locked
+				status: resp.body.status,
+				type: auth.type,
+				altname: altname
+			});
+	
+			// State can be pending while waiting ACME server to transition to
+			// processing
+			if ('pending' === resp.body.status) {
+				if (count >= MAX_PEND) {
+					return ACME._wait(RETRY_INTERVAL)
+						.then(deactivate)
+						.then(respondToChallenge);
+				}
+				//#console.debug('poll: again', auth.url);
+				return ACME._wait(RETRY_INTERVAL).then(pollStatus);
+			}
+	
+			if ('processing' === resp.body.status) {
+				//#console.debug('poll: again', auth.url);
+				return ACME._wait(RETRY_INTERVAL).then(pollStatus);
+			}
+	
+			// REMOVE DNS records as soon as the state is non-processing
+			// (valid or invalid or other)
+			try {
+				options.challenges[auth.type]
+					.remove({ challenge: auth })
+					.catch(function (err) {
+						err.action = 'challenge_remove';
+						err.altname = auth.altname;
+						err.type = auth.type;
+						ACME._notify(me, options, 'error', err);
+					});
+			} catch (e) {}
+	
+			if ('valid' === resp.body.status) {
+				if (me.debug) {
+					console.debug('poll: valid');
+				}
+	
+				return resp.body;
+			}
+	
+			var errmsg;
+			if (!resp.body.status) {
+				errmsg =
+					"[ACME.js] (E_STATE_EMPTY) empty challenge state for '" +
+					altname +
+					"':" +
+					JSON.stringify(resp.body);
+			} else if ('invalid' === resp.body.status) {
+				errmsg =
+					"[ACME.js] (E_STATE_INVALID) challenge state for '" +
+					altname +
+					"': '" +
+					//resp.body.status +
+					JSON.stringify(resp.body) +
+					"'";
+			} else {
+				errmsg =
+					"[ACME.js] (E_STATE_UKN) challenge state for '" +
+					altname +
+					"': '" +
+					resp.body.status +
+					"'";
+			}
+	
+			return Promise.reject(new Error(errmsg));
+		}
+	
+		function transformError(e) {
+			var err = e;
+			if (err.urn) {
+				err = new Error(
+					'[acme-v2] ' +
+						auth.altname +
+						' status:' +
+						e.status +
+						' ' +
+						e.detail
+				);
+				err.auth = auth;
+				err.altname = auth.altname;
+				err.type = auth.type;
+				err.code =
+					'invalid' === e.status ? 'E_ACME_CHALLENGE' : 'E_ACME_UNKNOWN';
+			}
+	
+			throw err;
+		}
+	
+		function respondToChallenge() {
+			//#console.debug('[ACME.js] responding to accept challenge:');
+			// POST-as-POST (empty JSON object)
+			return U._jwsRequest(me, {
+				accountKey: options.accountKey,
+				url: auth.url,
+				protected: { kid: kid },
+				payload: Enc.strToBuf(JSON.stringify({}))
+			})
+				.then(checkResult)
+				.catch(transformError);
+		}
+	
+		return respondToChallenge();
+	};
+	
+
+	ACME._pollOrderStatus = function (me, options, kid, order, verifieds) {
+		var csr64 = ACME._csrToUrlBase64(options.csr);
+		var body = { csr: csr64 };
+		var payload = JSON.stringify(body);
+	
+		function processResponse(resp) {
+			ACME._notify(me, options, 'certificate_status', {
+				subject: options.domains[0],
+				status: resp.body.status
+			});
+	
+			// https://tools.ietf.org/html/draft-ietf-acme-acme-12#section-7.1.3
+			// Possible values are: "pending" => ("invalid" || "ready") => "processing" => "valid"
+			if ('valid' === resp.body.status) {
+				var voucher = resp.body;
+				voucher._certificateUrl = resp.body.certificate;
+	
+				return voucher;
+			}
+	
+			if ('processing' === resp.body.status) {
+				return ACME._wait().then(pollStatus);
+			}
+	
+			if (me.debug) {
+				console.debug(
+					'Error: bad status:\n' + JSON.stringify(resp.body, null, 2)
+				);
+			}
+	
+			if ('pending' === resp.body.status) {
+				return Promise.reject(
+					new Error(
+						"Did not finalize order: status 'pending'." +
+							' Best guess: You have not accepted at least one challenge for each domain:\n' +
+							"Requested: '" +
+							options.domains.join(', ') +
+							"'\n" +
+							"Validated: '" +
+							verifieds.join(', ') +
+							"'\n" +
+							JSON.stringify(resp.body, null, 2)
+					)
+				);
+			}
+	
+			if ('invalid' === resp.body.status) {
+				return Promise.reject(
+					E.ORDER_INVALID(options, verifieds, resp)
+				);
+			}
+	
+			if ('ready' === resp.body.status) {
+				return Promise.reject(
+					E.DOUBLE_READY_ORDER(options, verifieds, resp)
+				);
+			}
+	
+			return Promise.reject(
+				E.UNHANDLED_ORDER_STATUS(options, verifieds, resp)
+			);
+		}
+	
+		function pollStatus() {
+			return U._jwsRequest(me, {
+				accountKey: options.accountKey,
+				url: order._orderUrl,
+				protected: { kid: kid },
+				payload: Enc.binToBuf('')
+			}).then(processResponse);
+		}
+	
+		function finalizeOrder() {
+			//#console.debug('[ACME.js] pollCert:', order._finalizeUrl);
+			return U._jwsRequest(me, {
+				accountKey: options.accountKey,
+				url: order._finalizeUrl,
+				protected: { kid: kid },
+				payload: Enc.strToBuf(payload)
+			}).then(processResponse);
+		}
+	
+		return finalizeOrder();
+	};
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import type { AdapterOptions } from '@iobroker/adapter-core';
 
 import pkg from '../package.json';
 import { create as createHttp01ChallengeServer } from './lib/http-01-challenge-server';
+import { applyPostAsGetPolling } from './lib/root-acme-post-as-get';
 import type { AcmeAdapterConfig } from './types';
 
 const accountObjectId = 'account';
@@ -287,6 +288,12 @@ class AcmeAdapter extends utils.Adapter {
                 ? 'https://acme-staging-v02.api.letsencrypt.org/directory'
                 : 'https://acme-v02.api.letsencrypt.org/directory';
             this.log.debug(`Using URL: ${directoryUrl}`);
+
+            // ACME.js as published on npm re-sends the challenge trigger and
+            // the order finalization, and today's Let's Encrypt rejects the
+            // repeats with 409 and 403 (#49). Restore the polling behaviour of
+            // the unpublished upstream 3.1.1 before anything uses the client.
+            applyPostAsGetPolling();
 
             this.acme = ACME.create({
                 maintainerEmail: this.config.maintainerEmail,


### PR DESCRIPTION
Closes #49.

`acme` as published on npm cannot finish an order against today's Let's Encrypt. This is #49, and this PR is offered as **one of several possible remedies** — please read the risks below before considering it, and reject it if you would rather take a different route. The diagnosis holds either way.

## What is broken

Two places in `@root/acme` 3.1.0 re-send a request that Boulder rejects.

**Challenge trigger → 409.** `_postChallenge` POSTs `{}` to the challenge URL and pipes the reply straight into `checkResult`. Boulder answers the first trigger with the challenge still `pending` — validation is queued, not done. ACME.js calls that impossible (`// This state should never occur`, `acme.js:764`) and triggers **again**; the repeat is answered with 409, which ACME.js then reads as if it were a challenge status: `(E_STATE_UKN) challenge state for '...': '409'`.

**Finalization → 403.** `_pollOrderStatus` POSTs the CSR to the finalize URL and, on `processing`, waits and **POSTs the CSR again** rather than polling the order URL as RFC 8555 §7.4 asks. Boulder answers `urn:ietf:params:acme:error:orderNotReady`, *Order's status ("valid") is not acceptable for finalization*, 403 — this issue's error verbatim.

Both are races. That is why the same adapter version issues certificates for some users and not others, and why #49 has been hard to pin down.

## The fix is upstream's own

The [acme.js repository](https://git.rootprojects.org/root/acme.js) is at **3.1.1** — tag `v3.1.1`, commit `45fd6962f259c6399de05589848d68be42894316`. The commit before it, `0aa939a2` *"Bug fix: Polling status using POST-as-GET wherever possible"* (2021-04-08, merged from `sam-lord`), fixes exactly both: `pending` goes to `pollStatus`, and finalization splits into `finalizeOrder()` (CSR once) and `pollStatus()` (POST-as-GET on `order._orderUrl`).

Tagged in May 2021. **Never published to npm.** npm still serves 3.1.0.

## Why this shape

`src/lib/root-acme-post-as-get.ts` carries those two functions verbatim from that tag and assigns them over the 3.1.0 ones before the client is used. They are writable properties on the object `require('acme')` returns, and the helpers they need (`@root/acme/utils.js`, `@root/acme/errors.js`, `@root/encoding/bytes.js`) are reachable from outside the package.

The alternatives I tried and discarded:

- **`overrides` pointing at the git tag.** Three lines, but every user's install would have to reach `git.rootprojects.org`. It installed once for me and then failed repeatedly with `gnutls_handshake() failed`, and later stopped answering plain HTTPS altogether. One self-hosted server as a hard install dependency, for Raspberry Pis, Docker images and Synology boxes, is not defensible.
- **A patch file plus `postinstall`.** `npm ci --ignore-scripts` skips it, and a silently unapplied patch means 409/403 at certificate time with no clue why — worse than the open bug.

This route needs no network fetch, no `postinstall`, and no mutation of `node_modules`, and it survives `--ignore-scripts`.

## Risks, plainly

- **The adapter takes on ~300 lines of somebody else's code**, copied from a release that was tagged and never shipped. That is a real maintenance liability and the main reason to say no.
- **It must be deleted** if `@root/acme` ever publishes a version containing the fix, or if the library is replaced. There is nothing that will remind you.
- **It reaches into another package's internals** — `@root/acme/utils.js` and friends are not a public API. If a future `@root/acme` reorganises them, this breaks at require time rather than silently, but it does break.
- **It is exempt from lint** (`/* eslint-disable */`) so that it stays diffable against upstream. Please do not let anyone reformat it.
- Given #169, where the plan is to move off this library, you may reasonably prefer to spend the effort there instead. This PR buys time; it is not a destination.

Deviation from upstream: exactly one token. `err.context = '...'` needed `(err as any).context` because TypeScript will not set an ad-hoc property on `Error`. Nothing else was touched.

## Verification

In an ioBroker dev environment (js-controller 7.2.2, admin 8.0.5) with `@root/acme` **3.1.0 installed unpatched**, ordering for a name never authorized before so that the full challenge cycle ran rather than reusing an authorization:

```
Collection dev1 does not exist - will create
Collection dev1 order success
```

Certificate returned by the staging CA, `CN=dev1.winkler.tel`. Without this change the same environment fails at the challenge with 409, or — if the challenge happens to win its race — at finalization with the 403 in #49.

The same two fixes were also verified outside ioBroker, against unpatched 3.1.0, for a reused authorization (finalization only) and a fresh one (full cycle): both issued in 61 s. Mechanism, measurements and code references: https://github.com/chris299/acme-dns-01-ednsde/blob/main/docs/acme-js-incompatibilities.md

