### PR TITLE
Add support for eDNS.de DNS-01 challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ See [AMCS.js](https://www.npmjs.com/package/acme) for more details.
 -->
 
 ## Changelog
+### **WORK IN PROGRESS**
+- (chris299) Added support for eDNS.de DNS-01 challenge
+
 ### 4.0.3 (2026-08-03)
 - (@GermanBluefox) Migrated to admin 8
 - (@GermanBluefox) Adapter requires admin >= 8.0.0 now

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -143,6 +143,10 @@
                         {
                             "label": "Netcup",
                             "value": "acme-dns-01-netcup"
+                        },
+                        {
+                            "label": "eDNS.de",
+                            "value": "acme-dns-01-ednsde"
                         }
                     ],
                     "xs": 12,
@@ -242,7 +246,7 @@
                     "md": 6,
                     "lg": 4,
                     "xl": 4,
-                    "hidden": "!data.dns01Active || !['acme-dns-01-cloudflare','acme-dns-01-digitalocean','acme-dns-01-dnsimple','acme-dns-01-duckdns','acme-dns-01-gandi','acme-dns-01-namedotcom', 'acme-dns-01-vultr'].includes(data.dns01Module)"
+                    "hidden": "!data.dns01Active || !['acme-dns-01-cloudflare','acme-dns-01-digitalocean','acme-dns-01-dnsimple','acme-dns-01-duckdns','acme-dns-01-ednsde','acme-dns-01-gandi','acme-dns-01-namedotcom', 'acme-dns-01-vultr'].includes(data.dns01Module)"
                 },
                 "dns01Ousername": {
                     "newLine": true,

--- a/build/main.js
+++ b/build/main.js
@@ -215,6 +215,20 @@ class AcmeAdapter extends utils.Adapter {
                     dns01Options.verifyPropagation = true;
                     delete dns01Props.propagationDelay;
                     break;
+                case 'acme-dns-01-ednsde':
+                    // eDNS' set() polls the zone's authoritative nameservers
+                    // until they all serve the record, so it reports
+                    // propagationDelay 0 and skipChallengeTest itself. Keep the
+                    // generic default from io-package.json from overwriting
+                    // that, or acme.js waits another two minutes for nothing.
+                    delete dns01Props.propagationDelay;
+                    // eDNS answers a name it has already published from a cache
+                    // with the record's 300s TTL, so a certificate covering a
+                    // domain and its wildcard waits that out once. Without
+                    // somewhere to report that, the log simply goes quiet for
+                    // minutes and looks like a hang.
+                    dns01Options.log = (message) => this.log.debug(`dns-01: ${message}`);
+                    break;
             }
             // Log dns-01 options with sensitive values redacted
             const safeOpts = { ...dns01Options };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "acme-dns-01-digitalocean": "^3.0.1",
         "acme-dns-01-dnsimple": "^3.0.0",
         "acme-dns-01-duckdns": "^3.0.1",
+        "acme-dns-01-ednsde": "^1.1.0",
         "acme-dns-01-gandi": "^3.0.0",
         "acme-dns-01-godaddy": "^3.0.1",
         "acme-dns-01-namecheap": "^3.0.1",
@@ -3016,6 +3017,15 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@root/request": "^1.3.11"
+      }
+    },
+    "node_modules/acme-dns-01-ednsde": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/acme-dns-01-ednsde/-/acme-dns-01-ednsde-1.1.0.tgz",
+      "integrity": "sha512-WBL/ModGykDZPzQvkUFJk6zz7H0uld1RUpFv2YubjF/nahjEp/nGqenn54mJg/FCDHaXX1vCKCv5ohBy3AQFZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/acme-dns-01-gandi": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "acme-dns-01-digitalocean": "^3.0.1",
     "acme-dns-01-dnsimple": "^3.0.0",
     "acme-dns-01-duckdns": "^3.0.1",
+    "acme-dns-01-ednsde": "^1.1.0",
     "acme-dns-01-gandi": "^3.0.0",
     "acme-dns-01-godaddy": "^3.0.1",
     "acme-dns-01-namecheap": "^3.0.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -225,6 +225,20 @@ class AcmeAdapter extends utils.Adapter {
                     dns01Options.verifyPropagation = true;
                     delete dns01Props.propagationDelay;
                     break;
+                case 'acme-dns-01-ednsde':
+                    // eDNS' set() polls the zone's authoritative nameservers
+                    // until they all serve the record, so it reports
+                    // propagationDelay 0 and skipChallengeTest itself. Keep the
+                    // generic default from io-package.json from overwriting
+                    // that, or acme.js waits another two minutes for nothing.
+                    delete dns01Props.propagationDelay;
+                    // eDNS answers a name it has already published from a cache
+                    // with the record's 300s TTL, so a certificate covering a
+                    // domain and its wildcard waits that out once. Without
+                    // somewhere to report that, the log simply goes quiet for
+                    // minutes and looks like a hang.
+                    dns01Options.log = (message: string) => this.log.debug(`dns-01: ${message}`);
+                    break;
             }
 
             // Log dns-01 options with sensitive values redacted

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -64,7 +64,8 @@ export interface AcmeAdapterConfig {
         | 'acme-dns-01-namedotcom'
         | 'acme-dns-01-route53'
         | 'acme-dns-01-vultr'
-        | 'acme-dns-01-netcup';
+        | 'acme-dns-01-netcup'
+        | 'acme-dns-01-ednsde';
     dns01OapiUser: string;
     dns01OapiKey: string;
     dns01OclientIp: string;


### PR DESCRIPTION
Closes #384.

[eDNS.de](https://edns.de) offers a purpose-built DNS-01 challenge API. [`acme-dns-01-ednsde`](https://www.npmjs.com/package/acme-dns-01-ednsde) implements the ACME.js challenge interface against it, MIT-licensed, with **no runtime dependencies of its own** — platform `fetch` and `node:dns`, nothing else.

## The changes

| File | |
| --- | --- |
| `package.json`, `package-lock.json` | the dependency, 10 lock lines |
| `admin/jsonConfig.json` | the provider in the `dns01Module` select, and the module name in the `hidden` expression of `dns01Otoken` — a token is the only credential eDNS needs, so no new field |
| `src/types.d.ts` | the module name in the `dns01Module` union, without which `tsc` rejects the switch case (TS2678) |
| `src/main.ts` | the switch case |
| `build/main.js` | rebuilt, following 97aafd5 (the Netcup commit) which does the same |
| `README.md` | changelog entry |

Seven files, 49 insertions.

## Two lines in the switch case that need a reason

**`delete dns01Props.propagationDelay`.** The plugin's `set()` polls the zone's authoritative nameservers until every one of them serves the record, and only then returns; it therefore reports `propagationDelay = 0` and `skipChallengeTest = true` from `create()`. Left in place, the generic `dns01PpropagationDelay` from `io-package.json` is written over that `0` after creation and ACME.js waits a further two minutes for a record it has already been told is in place. Netcup is special-cased for the same reason.

**`dns01Options.log = this.log.debug`.** eDNS answers a name it has already published from a cache carrying the record's own 300 s TTL. A certificate covering a domain and its wildcard puts two values on one `_acme-challenge` name, so the second one waits that cache out — measured at 314 s. On the first live run the adapter log went quiet for eleven minutes between *"will create"* and *"order success"*, which is indistinguishable from a hang and was read as one. The plugin is silent unless given somewhere to write; with this it reports the zone it settled on, what it is adding, how long it will wait and why, when the record became visible and on how many nameservers, and what it removed.

## Verification

In an ioBroker dev environment (js-controller 7.2.2, admin 8.0.5) against a live eDNS zone, from a clean state — no account, no collection, no leftover TXT records:

```
zone of 1ed7.winkler.tel is winkler.tel
adding TXT _greenlock-dryrun-470936d1.winkler.tel = gtM-…
_greenlock-dryrun-470936d1.winkler.tel serves the expected value on 2 of 2 nameserver(s) after 23s
…
adding TXT _acme-challenge.winkler.tel = _eGzxuNg…
_acme-challenge.winkler.tel serves the expected value on 2 of 2 nameserver(s) after 23s
adding TXT _acme-challenge.winkler.tel = E8I9xW_Z…
_acme-challenge.winkler.tel already carries other values, so eDNS publishes an added one
  only once its 300s record cache expires; waiting up to 360s
_acme-challenge.winkler.tel serves the expected value on 2 of 2 nameserver(s) after 314s
Collection winkler order success
```

A staging certificate covering `winkler.tel` and `*.winkler.tel` was stored in `system.certificates`. Saving the configuration dialog in admin 8 kept `dns01Module` as expected. The plugin also passes the `acme-dns-01-test` compliance harness, and issues staging certificates outside ioBroker.

## Three things found on the way, since they affect anyone testing this

**`acme` from npm cannot finish an order against today's Let's Encrypt.** If you try this PR on a fresh setup you are likely to see `(E_STATE_UKN) challenge state '409'` or `Didn't finalize order: Unhandled status '403'` (#49) — that is the client, not this plugin. Diagnosis and a possible remedy: #386. I would test this PR with that one applied, or you will be looking at the wrong component.

**Renewal currently never happens** — every run after the first dies with `Cannot read properties of undefined (reading '0')` (#191), because Let's Encrypt stopped returning the account `contact` field in January 2025. Fix in #385. Same caveat: without it, a second run of this PR crashes before it reaches any collection.

**Two small documentation points.** `CLAUDE.md` lists the encrypted native fields under "Configuration" as if they were in `common`; the `encryptedNative` array actually sits at the **top level** of `io-package.json`. And `npm run lint` cannot pass on a Windows checkout with `core.autocrlf=true` — `eslint.config.mjs`, `prettier.config.mjs`, `src/lib/http-01-challenge-server.ts` and `src/types.d.ts` produce a few hundred `Delete ␍` errors that have nothing to do with any change. I deliberately left those files alone rather than rewrite line endings across the repo.
